### PR TITLE
feat: add Open-Meteo provider and configurable weather cache

### DIFF
--- a/RealTimeWeatherMod/ChillEnvPlugin.cs
+++ b/RealTimeWeatherMod/ChillEnvPlugin.cs
@@ -26,10 +26,14 @@ namespace ChillWithYou.EnvSync
 
     // --- 配置项 ---
     internal static ConfigEntry<int> Cfg_WeatherRefreshMinutes;
+    internal static ConfigEntry<int> Cfg_CacheExpiryMinutes;
     internal static ConfigEntry<string> Cfg_SunriseTime;
     internal static ConfigEntry<string> Cfg_SunsetTime;
+    internal static ConfigEntry<string> Cfg_WeatherProvider;
     internal static ConfigEntry<string> Cfg_SeniverseKey;
     internal static ConfigEntry<string> Cfg_Location;
+    internal static ConfigEntry<double> Cfg_OpenMeteoLatitude;
+    internal static ConfigEntry<double> Cfg_OpenMeteoLongitude;
     internal static ConfigEntry<bool> Cfg_EnableTimeSync;
     internal static ConfigEntry<bool> Cfg_EnableWeatherSync;
     internal static ConfigEntry<bool> Cfg_UnlockEnvironments;
@@ -97,13 +101,17 @@ namespace ChillWithYou.EnvSync
     private void InitConfig()
     {
       Cfg_WeatherRefreshMinutes = Config.Bind("WeatherSync", "RefreshMinutes", 30, "天气API刷新间隔(分钟)");
+      Cfg_CacheExpiryMinutes = Config.Bind("WeatherSync", "CacheExpiryMinutes", 60, "天气缓存有效期(分钟)");
       Cfg_SunriseTime = Config.Bind("TimeConfig", "Sunrise", "06:30", "日出时间");
       Cfg_SunsetTime = Config.Bind("TimeConfig", "Sunset", "18:30", "日落时间");
       Cfg_EnableTimeSync = Config.Bind("TimeSync", "EnableTimeSync", true, "是否启用时间同步");
 
       Cfg_EnableWeatherSync = Config.Bind("WeatherAPI", "EnableWeatherSync", false, "是否启用天气API同步");
+      Cfg_WeatherProvider = Config.Bind("WeatherAPI", "WeatherProvider", "OpenMeteo", "天气数据源: Seniverse 或 OpenMeteo");
       Cfg_SeniverseKey = Config.Bind("WeatherAPI", "SeniverseKey", "", "心知天气 API Key");
       Cfg_Location = Config.Bind("WeatherAPI", "Location", "beijing", "城市名称");
+      Cfg_OpenMeteoLatitude = Config.Bind("WeatherAPI", "Latitude", 39.9042, "Open-Meteo 纬度");
+      Cfg_OpenMeteoLongitude = Config.Bind("WeatherAPI", "Longitude", 116.4074, "Open-Meteo 经度");
 
       Cfg_UnlockEnvironments = Config.Bind("Unlock", "UnlockAllEnvironments", true, "自动解锁环境");
       Cfg_UnlockDecorations = Config.Bind("Unlock", "UnlockAllDecorations", true, "自动解锁装饰道具");

--- a/RealTimeWeatherMod/Core/AutoEnvRunner.StartupSync.cs
+++ b/RealTimeWeatherMod/Core/AutoEnvRunner.StartupSync.cs
@@ -476,10 +476,16 @@ namespace ChillWithYou.EnvSync.Core
                         {
                             _pendingStartupWeather = weather;
                             UpdateUiWeatherString(weather);
-                            if (WeatherService.LastFetchSucceeded)
-                            {
-                                CheckAndSyncSunSchedule();
-                            }
+                    (weather) =>
+                    {
+                        _startupWeatherFetchFinished = true;
+                        if (weather != null)
+                        {
+                            _pendingStartupWeather = weather;
+                            UpdateUiWeatherString(weather);
+                        }
+                        CheckAndSyncSunSchedule();
+                    }
                         }
                     }));
             }

--- a/RealTimeWeatherMod/Core/AutoEnvRunner.StartupSync.cs
+++ b/RealTimeWeatherMod/Core/AutoEnvRunner.StartupSync.cs
@@ -460,6 +460,7 @@ namespace ChillWithYou.EnvSync.Core
                 _pendingStartupWeather = WeatherService.CachedWeather;
                 _startupWeatherFetchFinished = true;
                 UpdateUiWeatherString(_pendingStartupWeather);
+                CheckAndSyncSunSchedule();
             }
             else if (needWeatherFetch)
             {
@@ -475,12 +476,17 @@ namespace ChillWithYou.EnvSync.Core
                         {
                             _pendingStartupWeather = weather;
                             UpdateUiWeatherString(weather);
+                            if (WeatherService.LastFetchSucceeded)
+                            {
+                                CheckAndSyncSunSchedule();
+                            }
                         }
                     }));
             }
             else
             {
                 _startupWeatherFetchFinished = true;
+                CheckAndSyncSunSchedule();
             }
 
             float timeout = 30f;

--- a/RealTimeWeatherMod/Core/AutoEnvRunner.cs
+++ b/RealTimeWeatherMod/Core/AutoEnvRunner.cs
@@ -15,7 +15,7 @@ namespace ChillWithYou.EnvSync.Core
         private EnvironmentType? _lastAppliedEnv;
         private bool _isFetching;
         private bool _pendingForceRefresh;
-        private bool _isSunSyncRunning;
+        private float _nextSunSyncAttemptTime;
 
         private static AutoEnvRunner _instance;
 
@@ -30,7 +30,6 @@ namespace ChillWithYou.EnvSync.Core
             _nextTimeCheckTime = Time.time + 10f;
             ChillEnvPlugin.Log?.LogInfo("Runner 启动...");
 
-            CheckAndSyncSunSchedule();
             StartCoroutine(EarlyStartupSync());
         }
 
@@ -95,63 +94,43 @@ namespace ChillWithYou.EnvSync.Core
                 return;
             }
 
-            if (_isSunSyncRunning)
+            string lastSync = ChillEnvPlugin.Cfg_LastSunSyncDate.Value;
+            string today = DateTime.Now.ToString("yyyy-MM-dd");
+
+            if (lastSync == today || Time.time < _nextSunSyncAttemptTime)
             {
                 return;
             }
 
-            string lastSync = ChillEnvPlugin.Cfg_LastSunSyncDate.Value;
-            string today = DateTime.Now.ToString("yyyy-MM-dd");
-
-            if (lastSync != today)
-            {
-                StartCoroutine(SyncSunScheduleRoutine(today));
-            }
+            _nextSunSyncAttemptTime = Time.time + GetConfiguredWeatherRefreshSeconds();
+            StartCoroutine(SyncSunScheduleRoutine(today));
         }
 
         private System.Collections.IEnumerator SyncSunScheduleRoutine(string targetDate)
         {
-            _isSunSyncRunning = true;
-            int retryCount = 0;
-            float delay = 1f;
-            const int MaxRetries = 10;
+            bool success = false;
+            string apiKey = ChillEnvPlugin.Cfg_SeniverseKey.Value;
+            string location = ChillEnvPlugin.Cfg_Location.Value;
 
-            while (retryCount < MaxRetries)
+            yield return WeatherService.FetchSunSchedule(apiKey, location, (data) =>
             {
-                bool success = false;
-                string apiKey = ChillEnvPlugin.Cfg_SeniverseKey.Value;
-                string location = ChillEnvPlugin.Cfg_Location.Value;
-
-                yield return WeatherService.FetchSunSchedule(apiKey, location, (data) =>
+                if (data != null)
                 {
-                    if (data != null)
-                    {
-                        ChillEnvPlugin.Log?.LogInfo($"[SunSync] 同步成功: 日出{data.sunrise} 日落{data.sunset}");
+                    ChillEnvPlugin.Log?.LogInfo($"[SunSync] 同步成功: 日出{data.sunrise} 日落{data.sunset}");
 
-                        ChillEnvPlugin.Cfg_SunriseTime.Value = data.sunrise;
-                        ChillEnvPlugin.Cfg_SunsetTime.Value = data.sunset;
-                        ChillEnvPlugin.Cfg_LastSunSyncDate.Value = targetDate;
+                    ChillEnvPlugin.Cfg_SunriseTime.Value = data.sunrise;
+                    ChillEnvPlugin.Cfg_SunsetTime.Value = data.sunset;
+                    ChillEnvPlugin.Cfg_LastSunSyncDate.Value = targetDate;
 
-                        ChillEnvPlugin.Instance.Config.Save();
-                        success = true;
-                    }
-                });
-
-                if (success)
-                {
-                    _isSunSyncRunning = false;
-                    yield break;
+                    ChillEnvPlugin.Instance.Config.Save();
+                    success = true;
                 }
+            });
 
-                ChillEnvPlugin.Log?.LogWarning($"[SunSync] 同步失败，{delay}秒后重试 ({retryCount + 1}/{MaxRetries})");
-                yield return new WaitForSeconds(delay);
-
-                delay *= 2f;
-                retryCount++;
+            if (!success)
+            {
+                ChillEnvPlugin.Log?.LogWarning("[SunSync] 同步失败，保留现有日出日落设置");
             }
-
-            ChillEnvPlugin.Log?.LogError("[SunSync] 达到最大重试次数，今日放弃同步");
-            _isSunSyncRunning = false;
         }
 
         private void Update()
@@ -308,6 +287,7 @@ namespace ChillWithYou.EnvSync.Core
                     if (!forceApi && hasValidWeatherCache)
                     {
                         UpdateUiWeatherString(WeatherService.CachedWeather);
+                        CheckAndSyncSunSchedule();
                         ScheduleNextWeatherCheckFromCache(location);
                         return;
                     }
@@ -352,6 +332,7 @@ namespace ChillWithYou.EnvSync.Core
                 else if (policy.NeedWeatherDataForUI && hasValidWeatherCache)
                 {
                     UpdateUiWeatherString(WeatherService.CachedWeather);
+                    CheckAndSyncSunSchedule();
                     ScheduleNextWeatherCheckFromCache(location);
                 }
                 else
@@ -423,6 +404,7 @@ namespace ChillWithYou.EnvSync.Core
 
             if (shouldFetchWeather && hasValidWeatherCache)
             {
+                CheckAndSyncSunSchedule();
                 ScheduleNextWeatherCheckFromCache(location);
             }
             else

--- a/RealTimeWeatherMod/Core/AutoEnvRunner.cs
+++ b/RealTimeWeatherMod/Core/AutoEnvRunner.cs
@@ -15,6 +15,7 @@ namespace ChillWithYou.EnvSync.Core
         private EnvironmentType? _lastAppliedEnv;
         private bool _isFetching;
         private bool _pendingForceRefresh;
+        private bool _isSunSyncRunning;
 
         private static AutoEnvRunner _instance;
 
@@ -44,7 +45,7 @@ namespace ChillWithYou.EnvSync.Core
         private bool HasUsableApiKey()
         {
             string apiKey = ChillEnvPlugin.Cfg_SeniverseKey.Value;
-            return !string.IsNullOrEmpty(apiKey) || WeatherService.HasDefaultKey;
+            return WeatherService.HasUsableProvider(ChillEnvPlugin.Cfg_WeatherProvider.Value, apiKey);
         }
 
         private void UpdateUiWeatherString(WeatherInfo weather)
@@ -94,6 +95,11 @@ namespace ChillWithYou.EnvSync.Core
                 return;
             }
 
+            if (_isSunSyncRunning)
+            {
+                return;
+            }
+
             string lastSync = ChillEnvPlugin.Cfg_LastSunSyncDate.Value;
             string today = DateTime.Now.ToString("yyyy-MM-dd");
 
@@ -105,6 +111,7 @@ namespace ChillWithYou.EnvSync.Core
 
         private System.Collections.IEnumerator SyncSunScheduleRoutine(string targetDate)
         {
+            _isSunSyncRunning = true;
             int retryCount = 0;
             float delay = 1f;
             const int MaxRetries = 10;
@@ -132,6 +139,7 @@ namespace ChillWithYou.EnvSync.Core
 
                 if (success)
                 {
+                    _isSunSyncRunning = false;
                     yield break;
                 }
 
@@ -143,6 +151,7 @@ namespace ChillWithYou.EnvSync.Core
             }
 
             ChillEnvPlugin.Log?.LogError("[SunSync] 达到最大重试次数，今日放弃同步");
+            _isSunSyncRunning = false;
         }
 
         private void Update()
@@ -325,6 +334,11 @@ namespace ChillWithYou.EnvSync.Core
                             UpdateUiWeatherString(weather);
                             if (weather != null)
                             {
+                                if (WeatherService.LastFetchSucceeded)
+                                {
+                                    CheckAndSyncSunSchedule();
+                                }
+
                                 ScheduleNextWeatherCheckFromCache(location);
                             }
                             else
@@ -377,6 +391,11 @@ namespace ChillWithYou.EnvSync.Core
                         ApplyByPolicy(policy, weather, forceApply);
                         if (weather != null)
                         {
+                            if (WeatherService.LastFetchSucceeded)
+                            {
+                                CheckAndSyncSunSchedule();
+                            }
+
                             ScheduleNextWeatherCheckFromCache(location);
                         }
                         else

--- a/RealTimeWeatherMod/RealTimeWeather.csproj
+++ b/RealTimeWeatherMod/RealTimeWeather.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DecorationUnlockScanner.cs" />
     <Compile Include="Services\KeySecurity.cs" />
+    <Compile Include="Services\OpenMeteoWeatherMapper.cs" />
     <Compile Include="Services\WeatherService.cs" />
     <Compile Include="Utils\EnvRegistry.cs" />
     <Compile Include="Utils\WindowViewStateAccessor.cs" />

--- a/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
+++ b/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
@@ -59,7 +59,8 @@ namespace ChillWithYou.EnvSync.Services
                 return 26;
             }
 
-            if (weatherCode >= 1 && weatherCode <= 3 || cloudCover >= 65d)
+            // Codes 1-3 (partly cloudy/overcast) or clear sky with high measured cloud cover → Cloudy
+            if ((weatherCode >= 1 && weatherCode <= 3) || cloudCover >= 65d)
             {
                 return 4;
             }

--- a/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
+++ b/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
@@ -119,7 +119,7 @@ namespace ChillWithYou.EnvSync.Services
             if (normalizedCode == 13) return "LightRain";
             if (normalizedCode == 26) return "Fog";
             if (normalizedCode == 4) return "Cloudy";
-            return weatherCode == 0 ? "Clear" : "OpenMeteo";
+            return weatherCode == 0 ? "Clear" : $"OpenMeteo({weatherCode})";
         }
     }
 }

--- a/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
+++ b/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
@@ -108,12 +108,7 @@ namespace ChillWithYou.EnvSync.Services
 
         private static WeatherCondition ToCondition(int normalizedCode)
         {
-            if (normalizedCode >= 0 && normalizedCode <= 3) return WeatherCondition.Clear;
-            if (normalizedCode >= 4 && normalizedCode <= 9) return WeatherCondition.Cloudy;
-            if (normalizedCode >= 10 && normalizedCode <= 20) return WeatherCondition.Rainy;
-            if (normalizedCode >= 21 && normalizedCode <= 25) return WeatherCondition.Snowy;
-            if (normalizedCode >= 26 && normalizedCode <= 36) return WeatherCondition.Foggy;
-            return WeatherCondition.Unknown;
+            return WeatherService.MapCodeToCondition(normalizedCode);
         }
 
         private static string ToWeatherText(int weatherCode, int normalizedCode)

--- a/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
+++ b/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
@@ -1,0 +1,129 @@
+using System;
+using ChillWithYou.EnvSync.Models;
+
+namespace ChillWithYou.EnvSync.Services
+{
+    internal static class OpenMeteoWeatherMapper
+    {
+        internal static WeatherInfo Map(
+            int weatherCode,
+            double temperature,
+            double precipitation,
+            double rain,
+            double showers,
+            double snowfall,
+            double cloudCover,
+            DateTime updateTime)
+        {
+            int normalizedCode = ToSeniverseCode(weatherCode, precipitation, rain, showers, snowfall, cloudCover);
+            return new WeatherInfo
+            {
+                Code = normalizedCode,
+                Text = ToWeatherText(weatherCode, normalizedCode),
+                Temperature = (int)Math.Round(temperature),
+                Condition = ToCondition(normalizedCode),
+                UpdateTime = updateTime
+            };
+        }
+
+        internal static int ToSeniverseCode(
+            int weatherCode,
+            double precipitation,
+            double rain,
+            double showers,
+            double snowfall,
+            double cloudCover)
+        {
+            if (snowfall > 0d || IsSnow(weatherCode))
+            {
+                return 21;
+            }
+
+            if (IsThunder(weatherCode))
+            {
+                return 11;
+            }
+
+            if (IsHeavyRain(weatherCode) || precipitation >= 2.5d || rain + showers >= 2.5d)
+            {
+                return 14;
+            }
+
+            if (IsLightRain(weatherCode) || precipitation > 0d || rain > 0d || showers > 0d)
+            {
+                return 13;
+            }
+
+            if (weatherCode == 45 || weatherCode == 48)
+            {
+                return 26;
+            }
+
+            if (weatherCode >= 1 && weatherCode <= 3 || cloudCover >= 65d)
+            {
+                return 4;
+            }
+
+            return 1;
+        }
+
+        private static bool IsLightRain(int weatherCode)
+        {
+            return weatherCode == 51 ||
+                weatherCode == 53 ||
+                weatherCode == 55 ||
+                weatherCode == 56 ||
+                weatherCode == 57 ||
+                weatherCode == 61 ||
+                weatherCode == 63 ||
+                weatherCode == 80;
+        }
+
+        private static bool IsHeavyRain(int weatherCode)
+        {
+            return weatherCode == 65 ||
+                weatherCode == 66 ||
+                weatherCode == 67 ||
+                weatherCode == 81 ||
+                weatherCode == 82;
+        }
+
+        private static bool IsSnow(int weatherCode)
+        {
+            return weatherCode == 71 ||
+                weatherCode == 73 ||
+                weatherCode == 75 ||
+                weatherCode == 77 ||
+                weatherCode == 85 ||
+                weatherCode == 86;
+        }
+
+        private static bool IsThunder(int weatherCode)
+        {
+            return weatherCode == 95 ||
+                weatherCode == 96 ||
+                weatherCode == 99;
+        }
+
+        private static WeatherCondition ToCondition(int normalizedCode)
+        {
+            if (normalizedCode >= 0 && normalizedCode <= 3) return WeatherCondition.Clear;
+            if (normalizedCode >= 4 && normalizedCode <= 9) return WeatherCondition.Cloudy;
+            if (normalizedCode >= 10 && normalizedCode <= 20) return WeatherCondition.Rainy;
+            if (normalizedCode >= 21 && normalizedCode <= 25) return WeatherCondition.Snowy;
+            if (normalizedCode >= 26 && normalizedCode <= 36) return WeatherCondition.Foggy;
+            return WeatherCondition.Unknown;
+        }
+
+        private static string ToWeatherText(int weatherCode, int normalizedCode)
+        {
+            if (normalizedCode == 21) return "Snow";
+            if (normalizedCode == 11) return "ThunderRain";
+            if (normalizedCode == 14) return "HeavyRain";
+            if (normalizedCode == 13) return "LightRain";
+            if (normalizedCode == 26) return "Fog";
+            if (normalizedCode == 4) return "Cloudy";
+            return weatherCode == 0 ? "Clear" : "OpenMeteo";
+        }
+    }
+}

--- a/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
+++ b/RealTimeWeatherMod/Services/OpenMeteoWeatherMapper.cs
@@ -119,7 +119,7 @@ namespace ChillWithYou.EnvSync.Services
             if (normalizedCode == 13) return "LightRain";
             if (normalizedCode == 26) return "Fog";
             if (normalizedCode == 4) return "Cloudy";
-            return weatherCode == 0 ? "Clear" : $"OpenMeteo({weatherCode})";
+            return weatherCode == 0 ? "Clear" : "Unknown";
         }
     }
 }

--- a/RealTimeWeatherMod/Services/WeatherService.cs
+++ b/RealTimeWeatherMod/Services/WeatherService.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 using System.Collections;
-using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine.Networking;
 using ChillWithYou.EnvSync.Models;
 using Bulbul;
@@ -9,42 +9,75 @@ namespace ChillWithYou.EnvSync.Services
 {
     public class WeatherService
     {
+        private const string ProviderOpenMeteo = "OpenMeteo";
+
         private static WeatherInfo _cachedWeather;
         private static DateTime _lastFetchTime;
-        private static readonly TimeSpan CacheExpiry = TimeSpan.FromMinutes(60);
         private static string _lastLocation;
         public static WeatherInfo CachedWeather => _cachedWeather;
+        public static bool LastFetchSucceeded { get; private set; }
         private static readonly string _encryptedDefaultKey = "7Mr4YSR87bFvE4zDgj6NbuBKgz4EiPYEnRTQ0RIaeSU=";
         public static bool HasDefaultKey => !string.IsNullOrEmpty(_encryptedDefaultKey);
+
+        public static bool HasUsableProvider(string provider, string apiKey)
+        {
+            return IsOpenMeteoProvider(provider) || !string.IsNullOrEmpty(apiKey) || HasDefaultKey;
+        }
+
+        private static bool IsOpenMeteoProvider(string provider)
+        {
+            return string.Equals(provider?.Trim(), ProviderOpenMeteo, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int GetCacheExpiryMinutes()
+        {
+            return ChillEnvPlugin.Cfg_CacheExpiryMinutes != null ? ChillEnvPlugin.Cfg_CacheExpiryMinutes.Value : 60;
+        }
 
         private static string NormalizeLocation(string location)
         {
             return location?.Trim() ?? string.Empty;
         }
 
-        private static bool HasValidCacheNormalized(string normalizedLocation)
+        private static string GetCacheKey(string location)
+        {
+            if (IsOpenMeteoProvider(ChillEnvPlugin.Cfg_WeatherProvider?.Value))
+            {
+                double latitude = ChillEnvPlugin.Cfg_OpenMeteoLatitude?.Value ?? 39.9042d;
+                double longitude = ChillEnvPlugin.Cfg_OpenMeteoLongitude?.Value ?? 116.4074d;
+                return string.Format(CultureInfo.InvariantCulture, "OpenMeteo:{0:0.####},{1:0.####}", latitude, longitude);
+            }
+
+            return NormalizeLocation(location).ToLowerInvariant();
+        }
+
+        private static bool HasAnyCacheNormalized(string cacheKey)
         {
             return _cachedWeather != null &&
-                DateTime.Now - _lastFetchTime < CacheExpiry &&
-                string.Equals(_lastLocation, normalizedLocation, StringComparison.OrdinalIgnoreCase);
+                string.Equals(_lastLocation, cacheKey, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool HasValidCacheNormalized(string cacheKey)
+        {
+            return HasAnyCacheNormalized(cacheKey) &&
+                DateTime.Now - _lastFetchTime < TimeSpan.FromMinutes(GetCacheExpiryMinutes());
         }
 
         public static bool HasValidCache(string location)
         {
-            return HasValidCacheNormalized(NormalizeLocation(location));
+            return HasValidCacheNormalized(GetCacheKey(location));
         }
 
         public static bool TryGetCacheRemainingSeconds(string location, out float seconds)
         {
             seconds = 0f;
-            string normalizedLocation = NormalizeLocation(location);
-            if (!HasValidCacheNormalized(normalizedLocation))
+            string cacheKey = GetCacheKey(location);
+            if (!HasValidCacheNormalized(cacheKey))
             {
                 return false;
             }
 
-            TimeSpan elapsed = DateTime.Now - _lastFetchTime;
-            TimeSpan remaining = CacheExpiry - elapsed;
+            TimeSpan remaining = TimeSpan.FromMinutes(GetCacheExpiryMinutes()) - (DateTime.Now - _lastFetchTime);
             if (remaining < TimeSpan.Zero)
             {
                 remaining = TimeSpan.Zero;
@@ -56,14 +89,32 @@ namespace ChillWithYou.EnvSync.Services
 
         public static IEnumerator FetchWeather(string apiKey, string location, bool force, Action<WeatherInfo> onComplete)
         {
-            string normalizedLocation = NormalizeLocation(location);
+            LastFetchSucceeded = false;
+            string cacheKey = GetCacheKey(location);
 
-            if (!force && HasValidCacheNormalized(normalizedLocation))
+            if (!force && HasValidCacheNormalized(cacheKey))
             {
                 onComplete?.Invoke(_cachedWeather);
                 yield break;
             }
 
+            WeatherInfo fallback = HasAnyCacheNormalized(cacheKey) ? _cachedWeather : null;
+            if (IsOpenMeteoProvider(ChillEnvPlugin.Cfg_WeatherProvider?.Value))
+            {
+                yield return FetchOpenMeteoWeather(cacheKey, fallback, onComplete);
+                yield break;
+            }
+
+            yield return FetchSeniverseWeather(apiKey, location, cacheKey, fallback, onComplete);
+        }
+
+        private static IEnumerator FetchSeniverseWeather(
+            string apiKey,
+            string location,
+            string cacheKey,
+            WeatherInfo fallback,
+            Action<WeatherInfo> onComplete)
+        {
             string finalKey = apiKey;
             if (string.IsNullOrEmpty(finalKey) && HasDefaultKey)
             {
@@ -73,7 +124,7 @@ namespace ChillWithYou.EnvSync.Services
             if (string.IsNullOrEmpty(finalKey))
             {
                 ChillEnvPlugin.Log?.LogWarning("[API] 未配置 API Key 且无内置 Key");
-                onComplete?.Invoke(null);
+                onComplete?.Invoke(fallback);
                 yield break;
             }
 
@@ -88,7 +139,7 @@ namespace ChillWithYou.EnvSync.Services
                 if (request.result != UnityWebRequest.Result.Success || string.IsNullOrEmpty(request.downloadHandler.text))
                 {
                     ChillEnvPlugin.Log?.LogWarning($"[API] 请求失败: {request.error}");
-                    onComplete?.Invoke(null);
+                    onComplete?.Invoke(fallback);
                     yield break;
                 }
 
@@ -97,30 +148,77 @@ namespace ChillWithYou.EnvSync.Services
                     var weather = ParseWeatherJson(request.downloadHandler.text);
                     if (weather != null)
                     {
-                        _cachedWeather = weather;
-                        _lastFetchTime = DateTime.Now;
-                        _lastLocation = normalizedLocation;
+                        StoreCache(cacheKey, weather);
                         ChillEnvPlugin.Log?.LogInfo($"[API] 数据更新: {weather}");
                         onComplete?.Invoke(weather);
                     }
                     else
                     {
-                        ChillEnvPlugin.Log?.LogWarning($"[API] 解析失败");
-                        onComplete?.Invoke(null);
+                        ChillEnvPlugin.Log?.LogWarning("[API] 解析失败");
+                        onComplete?.Invoke(fallback);
                     }
                 }
-                catch { onComplete?.Invoke(null); }
+                catch { onComplete?.Invoke(fallback); }
             }
         }
 
-        /// <summary>
-        /// 主动清理缓存（如切换城市时）
-        /// </summary>
+        private static IEnumerator FetchOpenMeteoWeather(string cacheKey, WeatherInfo fallback, Action<WeatherInfo> onComplete)
+        {
+            double latitude = ChillEnvPlugin.Cfg_OpenMeteoLatitude?.Value ?? 39.9042d;
+            double longitude = ChillEnvPlugin.Cfg_OpenMeteoLongitude?.Value ?? 116.4074d;
+            string url = string.Format(
+                CultureInfo.InvariantCulture,
+                "https://api.open-meteo.com/v1/forecast?latitude={0}&longitude={1}&current=temperature_2m,relative_humidity_2m,precipitation,rain,showers,snowfall,weather_code,is_day,cloud_cover&timezone=auto&forecast_days=1",
+                latitude,
+                longitude);
+
+            ChillEnvPlugin.Log?.LogInfo($"[OpenMeteo] 发起请求: {latitude}, {longitude}");
+
+            using (UnityWebRequest request = UnityWebRequest.Get(url))
+            {
+                request.timeout = 10;
+                yield return request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success || string.IsNullOrEmpty(request.downloadHandler.text))
+                {
+                    ChillEnvPlugin.Log?.LogWarning($"[OpenMeteo] 请求失败: {request.error}");
+                    onComplete?.Invoke(fallback);
+                    yield break;
+                }
+
+                try
+                {
+                    var weather = ParseOpenMeteoWeatherJson(request.downloadHandler.text);
+                    if (weather != null)
+                    {
+                        StoreCache(cacheKey, weather);
+                        ChillEnvPlugin.Log?.LogInfo($"[OpenMeteo] 数据更新: {weather}");
+                        onComplete?.Invoke(weather);
+                    }
+                    else
+                    {
+                        ChillEnvPlugin.Log?.LogWarning("[OpenMeteo] 解析失败");
+                        onComplete?.Invoke(fallback);
+                    }
+                }
+                catch { onComplete?.Invoke(fallback); }
+            }
+        }
+
+        private static void StoreCache(string cacheKey, WeatherInfo weather)
+        {
+            _cachedWeather = weather;
+            _lastFetchTime = DateTime.Now;
+            _lastLocation = cacheKey;
+            LastFetchSucceeded = true;
+        }
+
         public static void InvalidateCache()
         {
             _cachedWeather = null;
             _lastLocation = null;
             _lastFetchTime = DateTime.MinValue;
+            LastFetchSucceeded = false;
         }
 
         private static WeatherInfo ParseWeatherJson(string json)
@@ -147,7 +245,42 @@ namespace ChillWithYou.EnvSync.Services
             catch { return null; }
         }
 
+        private static WeatherInfo ParseOpenMeteoWeatherJson(string json)
+        {
+            string current = ExtractObject(json, "\"current\":{");
+            if (string.IsNullOrEmpty(current)) return null;
+
+            int weatherCode = ExtractIntNumberValue(current, "\"weather_code\":");
+            double temperature = ExtractDoubleValue(current, "\"temperature_2m\":");
+            double precipitation = ExtractDoubleValue(current, "\"precipitation\":");
+            double rain = ExtractDoubleValue(current, "\"rain\":");
+            double showers = ExtractDoubleValue(current, "\"showers\":");
+            double snowfall = ExtractDoubleValue(current, "\"snowfall\":");
+            double cloudCover = ExtractDoubleValue(current, "\"cloud_cover\":");
+
+            return OpenMeteoWeatherMapper.Map(
+                weatherCode,
+                temperature,
+                precipitation,
+                rain,
+                showers,
+                snowfall,
+                cloudCover,
+                DateTime.Now);
+        }
+
         public static IEnumerator FetchSunSchedule(string apiKey, string location, Action<SunData> onComplete)
+        {
+            if (IsOpenMeteoProvider(ChillEnvPlugin.Cfg_WeatherProvider?.Value))
+            {
+                yield return FetchOpenMeteoSunSchedule(onComplete);
+                yield break;
+            }
+
+            yield return FetchSeniverseSunSchedule(apiKey, location, onComplete);
+        }
+
+        private static IEnumerator FetchSeniverseSunSchedule(string apiKey, string location, Action<SunData> onComplete)
         {
             string finalKey = apiKey;
             if (string.IsNullOrEmpty(finalKey) && HasDefaultKey)
@@ -161,7 +294,6 @@ namespace ChillWithYou.EnvSync.Services
                 yield break;
             }
 
-            // start=0&days=1 (Today)
             string url = $"https://api.seniverse.com/v3/geo/sun.json?key={finalKey}&location={UnityWebRequest.EscapeURL(location)}&language=zh-Hans&start=0&days=1";
             ChillEnvPlugin.Log?.LogInfo($"[API] 请求日出日落: {location}");
 
@@ -190,26 +322,77 @@ namespace ChillWithYou.EnvSync.Services
             }
         }
 
+        private static IEnumerator FetchOpenMeteoSunSchedule(Action<SunData> onComplete)
+        {
+            double latitude = ChillEnvPlugin.Cfg_OpenMeteoLatitude?.Value ?? 39.9042d;
+            double longitude = ChillEnvPlugin.Cfg_OpenMeteoLongitude?.Value ?? 116.4074d;
+            string url = string.Format(
+                CultureInfo.InvariantCulture,
+                "https://api.open-meteo.com/v1/forecast?latitude={0}&longitude={1}&daily=sunrise,sunset&timezone=auto&forecast_days=1",
+                latitude,
+                longitude);
+
+            ChillEnvPlugin.Log?.LogInfo($"[OpenMeteo] 请求日出日落: {latitude}, {longitude}");
+
+            using (UnityWebRequest request = UnityWebRequest.Get(url))
+            {
+                request.timeout = 15;
+                yield return request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success || string.IsNullOrEmpty(request.downloadHandler.text))
+                {
+                    ChillEnvPlugin.Log?.LogWarning($"[OpenMeteo] 日出日落请求失败: {request.error}");
+                    onComplete?.Invoke(null);
+                    yield break;
+                }
+
+                try
+                {
+                    var sunData = ParseOpenMeteoSunJson(request.downloadHandler.text);
+                    onComplete?.Invoke(sunData);
+                }
+                catch (Exception ex)
+                {
+                    ChillEnvPlugin.Log?.LogError($"[OpenMeteo] 日出日落解析失败: {ex}");
+                    onComplete?.Invoke(null);
+                }
+            }
+        }
+
         private static SunData ParseSunJson(string json)
         {
-            // Simple manual parsing to avoid heavy JSON library dependency if possible, 
-            // but since we have UnityEngine.JSONSerializeModule, we can try JsonUtility if the structure matches,
-            // OR just use string manipulation for robustness against extra fields.
-            // Given the structure is nested, manual parsing might be safer without a full JSON lib.
-            
-            // Structure: {"results":[{"sun":[{"date":"...","sunrise":"...","sunset":"..."}]}]}
-            
             int sunIndex = json.IndexOf("\"sun\"");
             if (sunIndex < 0) return null;
 
             string sunrise = ExtractStringValue(json, "\"sunrise\":\"", "\"");
             string sunset = ExtractStringValue(json, "\"sunset\":\"", "\"");
+
+            if (!string.IsNullOrEmpty(sunrise) && !string.IsNullOrEmpty(sunset))
+            {
+                return new SunData { sunrise = sunrise, sunset = sunset };
+            }
+            return null;
+        }
+
+        private static SunData ParseOpenMeteoSunJson(string json)
+        {
+            string sunrise = NormalizeOpenMeteoTime(ExtractFirstArrayString(json, "\"sunrise\":["));
+            string sunset = NormalizeOpenMeteoTime(ExtractFirstArrayString(json, "\"sunset\":["));
             
             if (!string.IsNullOrEmpty(sunrise) && !string.IsNullOrEmpty(sunset))
             {
                 return new SunData { sunrise = sunrise, sunset = sunset };
             }
             return null;
+        }
+
+        private static string NormalizeOpenMeteoTime(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return null;
+
+            int timeStart = value.IndexOf('T');
+            string time = timeStart >= 0 ? value.Substring(timeStart + 1) : value;
+            return time.Length >= 5 ? time.Substring(0, 5) : time;
         }
 
         private static int ExtractIntValue(string json, string prefix, string suffix)
@@ -219,6 +402,35 @@ namespace ChillWithYou.EnvSync.Services
             string val = json.Substring(start, end - start); int.TryParse(val, out int res); return res;
         }
 
+        private static int ExtractIntNumberValue(string json, string prefix)
+        {
+            return (int)Math.Round(ExtractDoubleValue(json, prefix));
+        }
+
+        private static double ExtractDoubleValue(string json, string prefix)
+        {
+            int start = json.IndexOf(prefix, StringComparison.Ordinal);
+            if (start < 0) return 0d;
+            start += prefix.Length;
+
+            while (start < json.Length && char.IsWhiteSpace(json[start]))
+            {
+                start++;
+            }
+
+            int end = start;
+            while (end < json.Length && "-+0123456789.".IndexOf(json[end]) >= 0)
+            {
+                end++;
+            }
+
+            if (end <= start) return 0d;
+
+            string val = json.Substring(start, end - start);
+            double res;
+            return double.TryParse(val, NumberStyles.Float, CultureInfo.InvariantCulture, out res) ? res : 0d;
+        }
+
         private static string ExtractStringValue(string json, string prefix, string suffix)
         {
             int start = json.IndexOf(prefix); if (start < 0) return null; start += prefix.Length;
@@ -226,13 +438,80 @@ namespace ChillWithYou.EnvSync.Services
             return json.Substring(start, end - start);
         }
 
+        private static string ExtractFirstArrayString(string json, string prefix)
+        {
+            int start = json.IndexOf(prefix, StringComparison.Ordinal);
+            if (start < 0) return null;
+            start += prefix.Length;
+
+            int quoteStart = json.IndexOf('"', start);
+            if (quoteStart < 0) return null;
+            int quoteEnd = json.IndexOf('"', quoteStart + 1);
+            if (quoteEnd < 0) return null;
+
+            return json.Substring(quoteStart + 1, quoteEnd - quoteStart - 1);
+        }
+
+        private static string ExtractObject(string json, string prefix)
+        {
+            int start = json.IndexOf(prefix, StringComparison.Ordinal);
+            if (start < 0) return null;
+            start += prefix.Length - 1;
+
+            int depth = 0;
+            bool inString = false;
+            bool escaped = false;
+
+            for (int i = start; i < json.Length; i++)
+            {
+                char ch = json[i];
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\' && inString)
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    inString = !inString;
+                    continue;
+                }
+
+                if (inString)
+                {
+                    continue;
+                }
+
+                if (ch == '{')
+                {
+                    depth++;
+                }
+                else if (ch == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return json.Substring(start, i - start + 1);
+                    }
+                }
+            }
+
+            return null;
+        }
+
         public static WeatherCondition MapCodeToCondition(int code)
         {
-            if (code >= 0 && code <= 3) return WeatherCondition.Clear;       // 晴
-            if (code >= 4 && code <= 9) return WeatherCondition.Cloudy;      // 阴/多云
-            if (code >= 10 && code <= 20) return WeatherCondition.Rainy;     // 雨
-            if (code >= 21 && code <= 25) return WeatherCondition.Snowy;     // 雪
-            if (code >= 26 && code <= 36) return WeatherCondition.Foggy;     // 雾/霾/沙尘暴
+            if (code >= 0 && code <= 3) return WeatherCondition.Clear;
+            if (code >= 4 && code <= 9) return WeatherCondition.Cloudy;
+            if (code >= 10 && code <= 20) return WeatherCondition.Rainy;
+            if (code >= 21 && code <= 25) return WeatherCondition.Snowy;
+            if (code >= 26 && code <= 36) return WeatherCondition.Foggy;
             return WeatherCondition.Unknown;
         }
     }

--- a/RealTimeWeatherMod/Services/WeatherService.cs
+++ b/RealTimeWeatherMod/Services/WeatherService.cs
@@ -94,6 +94,7 @@ namespace ChillWithYou.EnvSync.Services
 
             if (!force && HasValidCacheNormalized(cacheKey))
             {
+                LastFetchSucceeded = true;
                 onComplete?.Invoke(_cachedWeather);
                 yield break;
             }

--- a/RealTimeWeatherMod/Services/WeatherService.cs
+++ b/RealTimeWeatherMod/Services/WeatherService.cs
@@ -247,16 +247,16 @@ namespace ChillWithYou.EnvSync.Services
 
         private static WeatherInfo ParseOpenMeteoWeatherJson(string json)
         {
-            string current = ExtractObject(json, "\"current\":{");
+            string current = ExtractObjectProperty(json, "\"current\"");
             if (string.IsNullOrEmpty(current)) return null;
 
-            int weatherCode = ExtractIntNumberValue(current, "\"weather_code\":");
-            double temperature = ExtractDoubleValue(current, "\"temperature_2m\":");
-            double precipitation = ExtractDoubleValue(current, "\"precipitation\":");
-            double rain = ExtractDoubleValue(current, "\"rain\":");
-            double showers = ExtractDoubleValue(current, "\"showers\":");
-            double snowfall = ExtractDoubleValue(current, "\"snowfall\":");
-            double cloudCover = ExtractDoubleValue(current, "\"cloud_cover\":");
+            int weatherCode = ExtractIntNumberValue(current, "\"weather_code\"");
+            double temperature = ExtractDoubleValue(current, "\"temperature_2m\"");
+            double precipitation = ExtractDoubleValue(current, "\"precipitation\"");
+            double rain = ExtractDoubleValue(current, "\"rain\"");
+            double showers = ExtractDoubleValue(current, "\"showers\"");
+            double snowfall = ExtractDoubleValue(current, "\"snowfall\"");
+            double cloudCover = ExtractDoubleValue(current, "\"cloud_cover\"");
 
             return OpenMeteoWeatherMapper.Map(
                 weatherCode,
@@ -402,16 +402,19 @@ namespace ChillWithYou.EnvSync.Services
             string val = json.Substring(start, end - start); int.TryParse(val, out int res); return res;
         }
 
-        private static int ExtractIntNumberValue(string json, string prefix)
+        private static int ExtractIntNumberValue(string json, string propertyName)
         {
-            return (int)Math.Round(ExtractDoubleValue(json, prefix));
+            return (int)Math.Round(ExtractDoubleValue(json, propertyName));
         }
 
-        private static double ExtractDoubleValue(string json, string prefix)
+        private static double ExtractDoubleValue(string json, string propertyName)
         {
-            int start = json.IndexOf(prefix, StringComparison.Ordinal);
+            int start = json.IndexOf(propertyName, StringComparison.Ordinal);
             if (start < 0) return 0d;
-            start += prefix.Length;
+
+            int colon = json.IndexOf(':', start + propertyName.Length);
+            if (colon < 0) return 0d;
+            start = colon + 1;
 
             while (start < json.Length && char.IsWhiteSpace(json[start]))
             {
@@ -452,11 +455,16 @@ namespace ChillWithYou.EnvSync.Services
             return json.Substring(quoteStart + 1, quoteEnd - quoteStart - 1);
         }
 
-        private static string ExtractObject(string json, string prefix)
+        private static string ExtractObjectProperty(string json, string propertyName)
         {
-            int start = json.IndexOf(prefix, StringComparison.Ordinal);
+            int nameStart = json.IndexOf(propertyName, StringComparison.Ordinal);
+            if (nameStart < 0) return null;
+
+            int colon = json.IndexOf(':', nameStart + propertyName.Length);
+            if (colon < 0) return null;
+
+            int start = json.IndexOf('{', colon + 1);
             if (start < 0) return null;
-            start += prefix.Length - 1;
 
             int depth = 0;
             bool inString = false;


### PR DESCRIPTION
## Changes
- Add Open-Meteo as a keyless weather provider using configured latitude/longitude.
- Add CacheExpiryMinutes to replace the hard-coded 60-minute weather cache TTL.
- Keep the existing cache-driven scheduler: valid cache delays the next check until cache expiry; F7 still bypasses cache.
- Retry daily sunrise/sunset sync after a successful weather fetch when LastSunSyncDate is still stale.

## Notes
- Existing Seniverse provider remains available.
- Weather cache stays in memory; Sunrise/Sunset continue to be persisted in config.

## Validation
- dotnet build could not run in this environment because .NET Framework 4.7.2 targeting pack is missing.
- dotnet test could not run in this environment because only .NET SDK 6.0 is installed while tests target net9.0.